### PR TITLE
Add coordinates to color table

### DIFF
--- a/src/app/color-coordinate/color-coordinate.component.html
+++ b/src/app/color-coordinate/color-coordinate.component.html
@@ -75,13 +75,14 @@
                 </option>
               </select>
             </td>
-            <td [style.backgroundColor]="selectedColors[i]"></td>
+            <td [style.backgroundColor]="selectedColors[i]" [id]="selectedColors[i]" class="color-mid-col"></td>
+            <td class="right-col" id="right-col"></td>
           </tr>
         </table>
       </div>
       
       <div *ngIf="isGridGenerated" id="grid-container" [ngClass]="{'hidden': !isGridGenerated}">
-        <table class="coordinate-grid">
+        <table class="coordinate-grid" id="coordinate-grid">
           <tr>
             <th></th>
             <th *ngFor="let col of columnHeaders">{{col}}</th>

--- a/src/app/color-coordinate/color-coordinate.component.ts
+++ b/src/app/color-coordinate/color-coordinate.component.ts
@@ -77,11 +77,30 @@ export class ColorCoordinateComponent implements OnInit {
   }
   
   updateColorSelection(index: number): void {
+    //index is for new color from selectedColors table
+    //idea is loop through colors-tbl, split string, get cellnames
+    //loop through grid, check if cell coordinate (textContent?) matches cellname
+    //if match, update this.gridCellColors[rowindex][colIndex] = this.selectedColors[index]
   }
   
   cellClicked(rowIndex: number, colIndex: number, rowNumber: number, colHeader: string): void {
     if (this.selectedColorIndex >= 0 && this.selectedColorIndex < this.selectedColors.length) {
       this.gridCellColors[rowIndex][colIndex] = this.selectedColors[this.selectedColorIndex];
+      let cellName = colHeader + "" + rowNumber + ",";
+      var textNode = document.createTextNode(cellName);
+      var table = document.getElementById("colors-tbl") as HTMLTableElement;
+      for (var i = 0, row; row = table.rows[i]; i++) {
+        var checkcol = row.cells[2];
+        let newtext = checkcol.textContent?.replaceAll(cellName, "");
+        if (checkcol.textContent != null && newtext != undefined) {
+          checkcol.textContent = newtext;
+        }
+        var colorcol = row.cells[1];
+        if (colorcol.id == this.selectedColors[this.selectedColorIndex]) {
+          var rightcol = row.cells[2];
+          rightcol.appendChild(textNode);
+        }
+      }
     }
   }
   


### PR DESCRIPTION
This adds the function so that when a grid cell is clicked, it will add the cell's coordinates to the top color table. Also adds function so that when a colored cell is clicked with a new color selected, the coordinate will be removed from the previous color row and be added to the new color's row in the color table.